### PR TITLE
Convert auth system to use the new roles service

### DIFF
--- a/handler/Roles.go
+++ b/handler/Roles.go
@@ -590,7 +590,6 @@ func (h *rolesHandler) AddMembers(ctx context.Context, request *rolesrv.Members,
 		return err
 	}
 
-	h.syncMembers(ctx)
 	response = &rolesrv.NilMessage{}
 	return nil
 }
@@ -622,7 +621,6 @@ func (h *rolesHandler) RemoveMembers(ctx context.Context, request *rolesrv.Membe
 		return err
 	}
 
-	h.syncMembers(ctx)
 	response = &rolesrv.NilMessage{}
 	return nil
 }


### PR DESCRIPTION
Completely gutted the concept of roles from auth-cmd and auth-srv.

Now auth updates role-srv with filters and roles.